### PR TITLE
Fixed syntax to please YUI compressor

### DIFF
--- a/bigtext.js
+++ b/bigtext.js
@@ -112,8 +112,8 @@
             ratios = [];
 
         $c.find(childSelector).css({
-            float: 'left',
-            clear: 'left'
+            'float': 'left',
+            'clear': 'left'
         }).each(function(lineNumber) {
             var $line = $(this),
                 intervals = [4,1,.4,.1],


### PR DESCRIPTION
I implemented BigText in a Rails project which uses the YUI compressor in its asset pipeline. YUI was throwing an error due to (what it called) a syntax error. Adding quotes around these two properties fixes the issue.
