### PR TITLE
Fix RegExp used to remove existing line classes

### DIFF
--- a/bigtext.js
+++ b/bigtext.js
@@ -111,7 +111,7 @@
                     $t.find(childSelector).addClass(function(lineNumber, className)
                     {
                         // remove existing line classes.
-                        return [className.replace(new RegExp('(?:^|\\s+)' + BigText.LINE_CLASS_PREFIX + '\\d+'), ''),
+                        return [className.replace(new RegExp('\\b' + BigText.LINE_CLASS_PREFIX + '\\d+\\b'), ''),
                                 BigText.LINE_CLASS_PREFIX + lineNumber].join(' ');
                     });
         


### PR DESCRIPTION
It previously looked for _zero_ or more space characters (\s*) before the LINE_CLASS_PREFIX, which could have caused it to also match other classes irrelevant to BigText. To prevent that, now it matches either the beginning of the line (^) or one or more space characters (\s+).
