### PR TITLE
removing underscore dependency

### DIFF
--- a/bigtext.js
+++ b/bigtext.js
@@ -51,8 +51,6 @@
           if($.fn.smartresize) {
             // https://github.com/lrbabe/jquery-smartresize/
             eventName = 'smartresize.' + eventName;
-          } else if(_.debounce) {
-            resizeFunction = _.debounce(resizeFunction, 200);
           }
           $(window).unbind(eventName).bind(eventName, resizeFunction);
         }


### PR DESCRIPTION
This resolves the error `_ is undefined` for people that do not want to add the underscore library to their project by removing the else condition that utilizes `_.debounce`

A better solution would be to check if underscore exists and fail gracefully.  I am not familiar with `_.debounce` so I did not attempt to do this.
