### PR TITLE
Adding typeof check to window.getComputedStyle

### DIFF
--- a/bigtext.js
+++ b/bigtext.js
@@ -32,6 +32,9 @@
               position: 'absolute',
               'font-size': '14.1px'
             }).appendTo(document.body).get(0),
+            computedStyle;
+            
+          if(typeof window.getComputedStyle == 'object')
             computedStyle = window.getComputedStyle( test, null );
 
           return computedStyle ? computedStyle.getPropertyValue( 'font-size' ) === '14px' : true;


### PR DESCRIPTION
Hopefully fixes [#43](https://github.com/zachleat/BigText/issues/43) with Firefox.
