### PR TITLE
Add check for null body in noFractionalFontSize

### DIFF
--- a/dist/bigtext.js
+++ b/dist/bigtext.js
@@ -1,4 +1,4 @@
-/*! BigText - v0.1.6 - 2014-04-21
+/*! BigText - v0.1.6 - 2014-07-01
  * https://github.com/zachleat/bigtext
  * Copyright (c) 2014 Zach Leatherman (@zachleat)
  * MIT License */
@@ -28,7 +28,7 @@
       },
       test: {
         noFractionalFontSize: (function() {
-          if( !( 'getComputedStyle' in window ) || !( 'body' in document ) ) {
+          if( !( 'getComputedStyle' in window ) || !( 'body' in document ) || document.body == null ) {
             return true;
           }
           var test = $('<div/>').css({

--- a/src/bigtext.js
+++ b/src/bigtext.js
@@ -23,7 +23,7 @@
       },
       test: {
         noFractionalFontSize: (function() {
-          if( !( 'getComputedStyle' in window ) || !( 'body' in document ) ) {
+          if( !( 'getComputedStyle' in window ) || !( 'body' in document ) || document.body == null ) {
             return true;
           }
           var test = $('<div/>').css({


### PR DESCRIPTION
Implementing the fix suggested here:
https://github.com/zachleat/BigText/issues/55
