### PR TITLE
Fix word-spacing adjustment (#69)

### DIFF
--- a/dist/bigtext.js
+++ b/dist/bigtext.js
@@ -1,4 +1,4 @@
-/*! BigText - v0.1.8 - 2015-02-28
+/*! BigText - v0.1.8 - 2015-04-25
  * https://github.com/zachleat/bigtext
  * Copyright (c) 2015 Zach Leatherman (@zachleat)
  * MIT License */
@@ -136,7 +136,9 @@
 
   function testLineDimensions($line, maxWidth, property, size, interval, units, previousWidth)
   {
-    var width;
+    var width,
+      return_size;
+
     previousWidth = typeof previousWidth === 'number' ? previousWidth : 0;
     $line.css(property, size + units);
 
@@ -147,9 +149,13 @@
       $line.css(property, '');
 
       if(width === maxWidth) {
+        return_size = parseFloat((parseFloat(size) - 0.1).toFixed(3));
+        if(BigText.supports.wholeNumberFontSizeOnly) {
+          return_size = Math.round(return_size);
+        }
         return {
           match: 'exact',
-          size: parseFloat((parseFloat(size) - 0.1).toFixed(3))
+          size: return_size
         };
       }
 
@@ -159,9 +165,14 @@
       var under = maxWidth - previousWidth,
         over = width - maxWidth;
 
+      return_size = parseFloat((parseFloat(size) - (property === 'word-spacing' && previousWidth && ( over < under ) ? 0 : interval)).toFixed(3));
+      if(BigText.supports.wholeNumberFontSizeOnly) {
+        return_size = Math.round(return_size);
+      }
+
       return {
         match: 'estimate',
-        size: parseFloat((parseFloat(size) - (property === 'word-spacing' && previousWidth && ( over < under ) ? 0 : interval)).toFixed(3))
+        size: return_size
       };
     }
 
@@ -258,7 +269,7 @@
       // must re-use font-size, even though it was removed above.
       $line.css('font-size', fontSizes[lineNumber] + 'px');
 
-      for(var m=1, n=3; m<n; m+=interval) {
+      for(var m=1, n=20; m<n; m+=interval) {
         maxWordSpacing = testLineDimensions($line, maxWidth, 'word-spacing', m, interval, 'px', maxWordSpacing);
         if(typeof maxWordSpacing !== 'number') {
           wordSpacing = maxWordSpacing.size;

--- a/src/bigtext.js
+++ b/src/bigtext.js
@@ -131,7 +131,9 @@
 
   function testLineDimensions($line, maxWidth, property, size, interval, units, previousWidth)
   {
-    var width;
+    var width,
+      return_size;
+
     previousWidth = typeof previousWidth === 'number' ? previousWidth : 0;
     $line.css(property, size + units);
 
@@ -142,9 +144,13 @@
       $line.css(property, '');
 
       if(width === maxWidth) {
+        return_size = parseFloat((parseFloat(size) - 0.1).toFixed(3));
+        if(BigText.supports.wholeNumberFontSizeOnly) {
+          return_size = Math.round(return_size);
+        }
         return {
           match: 'exact',
-          size: parseFloat((parseFloat(size) - 0.1).toFixed(3))
+          size: return_size
         };
       }
 
@@ -154,9 +160,14 @@
       var under = maxWidth - previousWidth,
         over = width - maxWidth;
 
+      return_size = parseFloat((parseFloat(size) - (property === 'word-spacing' && previousWidth && ( over < under ) ? 0 : interval)).toFixed(3));
+      if(BigText.supports.wholeNumberFontSizeOnly) {
+        return_size = Math.round(return_size);
+      }
+
       return {
         match: 'estimate',
-        size: parseFloat((parseFloat(size) - (property === 'word-spacing' && previousWidth && ( over < under ) ? 0 : interval)).toFixed(3))
+        size: return_size
       };
     }
 
@@ -253,7 +264,7 @@
       // must re-use font-size, even though it was removed above.
       $line.css('font-size', fontSizes[lineNumber] + 'px');
 
-      for(var m=1, n=3; m<n; m+=interval) {
+      for(var m=1, n=20; m<n; m+=interval) {
         maxWordSpacing = testLineDimensions($line, maxWidth, 'word-spacing', m, interval, 'px', maxWordSpacing);
         if(typeof maxWordSpacing !== 'number') {
           wordSpacing = maxWordSpacing.size;


### PR DESCRIPTION
Two improvements:
- Line 267: iteration is now going up to 20px. Before it was only 3px
  which wasn't enough in some cases. In my tests it took never more then
  5px to exceed the maxWidth. So 20px should be fine (also for long
  words)
- Line 147, 163: For browsers with no support for subpixel font scaling,
  it seems to be necessary to round the values, because they might get
  rounded incorrectly. At least my Safari (6.1.6) took 0.9px for 0px
