### PR TITLE
Fix for maxFontSize logic

### DIFF
--- a/dist/bigtext.js
+++ b/dist/bigtext.js
@@ -1,4 +1,4 @@
-/*! BigText - v0.1.8 - 2015-02-28
+/*! BigText - v0.1.8 - 2015-05-25
  * https://github.com/zachleat/bigtext
  * Copyright (c) 2015 Zach Leatherman (@zachleat)
  * MIT License */
@@ -215,7 +215,7 @@
 
       outer: for(var m=0, n=intervals.length; m<n; m++) {
         inner: for(var j=1, k=10; j<=k; j++) {
-          if(newFontSize + j*intervals[m] > maxFontSize) {
+          if(newFontSize + j*intervals[m] - 10 > maxFontSize) {
             newFontSize = maxFontSize;
             break outer;
           }

--- a/dist/test/tests.js
+++ b/dist/test/tests.js
@@ -187,6 +187,19 @@
       'Font size should equal the maximum.');
   });
 
+  test('testCloseToMaxFontSize', function()
+  {
+    $('#qunit-fixture').html('<div id="test" style="width:140px"><div>Hello</div></div>');
+    $('#test').bigtext();
+    var font_size_without_max = $('#test > div').css('font-size');
+
+    $('#test').bigtext( { maxfontsize: parseInt(font_size_without_max)+1 } );
+    var font_size_with_max = $('#test > div').css('font-size');
+
+    equal(font_size_with_max, font_size_without_max,
+      'Font size should equal the maximum.');
+  });
+
   test('testUnbrokenSingleWord', function()
   {
     $('#qunit-fixture').html('<div id="test" style="width:300px"><div>This</div></div>');

--- a/dist/test/tests.js
+++ b/dist/test/tests.js
@@ -197,7 +197,7 @@
     var font_size_with_max = $('#test > div').css('font-size');
 
     equal(font_size_with_max, font_size_without_max,
-      'Font size should equal the maximum.');
+      'Font size should not equal the maximum.');
   });
 
   test('testUnbrokenSingleWord', function()

--- a/src/bigtext-test.js
+++ b/src/bigtext-test.js
@@ -188,6 +188,19 @@
       'Font size should equal the maximum.');
   });
 
+  test('testCloseToMaxFontSize', function()
+  {
+    $('#qunit-fixture').html('<div id="test" style="width:140px"><div>Hello</div></div>');
+    $('#test').bigtext();
+    var font_size_without_max = $('#test > div').css('font-size');
+
+    $('#test').bigtext( { maxfontsize: parseInt(font_size_without_max)+1 } );
+    var font_size_with_max = $('#test > div').css('font-size');
+
+    equal(font_size_with_max, font_size_without_max,
+      'Font size should equal the maximum.');
+  });
+
   test('testUnbrokenSingleWord', function()
   {
     $('#qunit-fixture').html('<div id="test" style="width:300px"><div>This</div></div>');

--- a/src/bigtext-test.js
+++ b/src/bigtext-test.js
@@ -198,7 +198,7 @@
     var font_size_with_max = $('#test > div').css('font-size');
 
     equal(font_size_with_max, font_size_without_max,
-      'Font size should equal the maximum.');
+      'Font size should not equal the maximum.');
   });
 
   test('testUnbrokenSingleWord', function()

--- a/src/bigtext.js
+++ b/src/bigtext.js
@@ -210,7 +210,7 @@
 
       outer: for(var m=0, n=intervals.length; m<n; m++) {
         inner: for(var j=1, k=10; j<=k; j++) {
-          if(newFontSize + j*intervals[m] > maxFontSize) {
+          if(newFontSize + j*intervals[m] - 10 > maxFontSize) {
             newFontSize = maxFontSize;
             break outer;
           }


### PR DESCRIPTION
This is an awesome library thanks for putting it together!

When I implemented I found that the auto sizing was "sticking" to the maxfontsize when the auto-scaled font size was close to the maxFontSize. A couple of debug statements in the font size calculation show that the maxFontSize was getting enforced when the font value was still debouncing.

I added a test that reproduces this bug. The fix that I implemented (fudge factor of 10) isn't super elegant but I think it does the trick considering that it only makes sense to break out of the font size calculation loop when the estimated font size is wildly larger than the maxFontSize.
