### PR TITLE
docs: Fix simple typo, compontent -> component

### DIFF
--- a/demo/js/modernizr-1.6.js
+++ b/demo/js/modernizr-1.6.js
@@ -798,7 +798,7 @@ window.Modernizr = (function(window,doc,undefined){
                       bool = f.checkValidity && f.checkValidity() === false;
                       
                     } else {
-                      // If the upgraded input compontent rejects the :) text, we got a winner
+                      // If the upgraded input component rejects the :) text, we got a winner
                       bool = f.value != smile;
                     }
                 }


### PR DESCRIPTION
There is a small typo in demo/js/modernizr-1.6.js.

Should read `component` rather than `compontent`.

